### PR TITLE
Remove extern lib declaration

### DIFF
--- a/gpu-descriptor/src/lib.rs
+++ b/gpu-descriptor/src/lib.rs
@@ -12,8 +12,6 @@
     unused_qualifications
 )]
 
-extern crate alloc;
-
 mod allocator;
 
 pub use crate::allocator::*;


### PR DESCRIPTION
Shouldn't be needed for rust2018