### PR TITLE
Clean up the unused buckets

### DIFF
--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -530,6 +530,7 @@ impl<P, S> DescriptorAllocator<P, S> {
         for bucket in self.buckets.values_mut() {
             bucket.cleanup(device)
         }
+        self.buckets.retain(|_, bucket| !bucket.pools.is_empty());
     }
 }
 


### PR DESCRIPTION
Otherwise we are getting the warning on destruction:
>`DescriptorAllocator` is dropped while some descriptor sets were not deallocated