### PR TITLE
Require ExactSizeIterator

### DIFF
--- a/gfx/src/lib.rs
+++ b/gfx/src/lib.rs
@@ -200,7 +200,7 @@ where
     unsafe fn alloc_descriptor_sets<'a>(
         &self,
         pool: &mut B::DescriptorPool,
-        layouts: impl Iterator<Item = &'a B::DescriptorSetLayout>,
+        layouts: impl ExactSizeIterator<Item = &'a B::DescriptorSetLayout>,
         sets: &mut impl Extend<B::DescriptorSet>,
     ) -> Result<(), DeviceAllocationError> {
         match pool.allocate(layouts, sets) {

--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -204,7 +204,7 @@ impl<P> DescriptorBucket<P> {
 
             let result = device.alloc_descriptor_sets(
                 &mut pool.raw,
-                core::iter::repeat(layout).take(allocate as usize),
+                (0..allocate).map(|_| layout),
                 &mut Allocation {
                     size: self.size,
                     update_after_bind: self.update_after_bind,
@@ -269,7 +269,7 @@ impl<P> DescriptorBucket<P> {
             let allocate = max_sets.min(count);
             let result = device.alloc_descriptor_sets(
                 &mut raw,
-                core::iter::repeat(layout).take(allocate as usize),
+                (0..allocate).map(|_| layout),
                 &mut Allocation {
                     pool_id,
                     size: self.size,

--- a/types/src/device.rs
+++ b/types/src/device.rs
@@ -43,7 +43,7 @@ pub trait DescriptorDevice<L, P, S> {
     unsafe fn alloc_descriptor_sets<'a>(
         &self,
         pool: &mut P,
-        layouts: impl Iterator<Item = &'a L>,
+        layouts: impl ExactSizeIterator<Item = &'a L>,
         sets: &mut impl Extend<S>,
     ) -> Result<(), DeviceAllocationError>
     where


### PR DESCRIPTION
Having `ExactSizeIterator` makes it easier for `gpu-descriptor` clients to work with the iterator, allocate memory, etc. We've already required this on most things in gfx-hal, but now realized that descriptor allocation was missing this bound. So it is becoming a requirement. I don't think there are any downsides, are there?