### PR TITLE
Don't panic in panic on drop

### DIFF
--- a/.github/workflows/fast-pr-check.yml
+++ b/.github/workflows/fast-pr-check.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
+    - name: Check no_std 
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --manifest-path gpu-descriptor/Cargo.toml --no-default-features
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:

--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -114,15 +114,17 @@ struct DescriptorBucket<P> {
 
 impl<P> Drop for DescriptorBucket<P> {
     fn drop(&mut self) {
-        assert_eq!(
-            self.total, 0,
-            "Allocator dropped before all sets were deallocated"
-        );
+        if !std::thread::panicking() {
+            assert_eq!(
+                self.total, 0,
+                "Allocator dropped before all sets were deallocated"
+            );
 
-        assert!(
-            self.pools.is_empty(),
-            "All sets deallocated but pools were not. Make sure to call `Allocator::cleanup`"
-        );
+            assert!(
+                self.pools.is_empty(),
+                "All sets deallocated but pools were not. Make sure to call `Allocator::cleanup`"
+            );
+        }
     }
 }
 

--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -114,6 +114,7 @@ struct DescriptorBucket<P> {
 
 impl<P> Drop for DescriptorBucket<P> {
     fn drop(&mut self) {
+        #[cfg(feature = "std")]
         if !std::thread::panicking() {
             assert_eq!(
                 self.total, 0,


### PR DESCRIPTION
Panicking here makes debugging hard, and it prevents other states from cleaning up after themselves.