### PR TITLE
Fix cleanup warning check

### DIFF
--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -381,7 +381,7 @@ pub struct DescriptorAllocator<P, S> {
 
 impl<P, S> Drop for DescriptorAllocator<P, S> {
     fn drop(&mut self) {
-        if !self.buckets.is_empty() {
+        if self.buckets.drain().any(|(_, bucket)| bucket.total != 0) {
             #[cfg(feature = "tracing")]
             tracing::error!(
                 "`DescriptorAllocator` is dropped while some descriptor sets were not deallocated"


### PR DESCRIPTION
Seeing this warning firing up is annoying:
> (gpu_descriptor::allocator): DescriptorAllocator is dropped while some descriptor sets were not deallocated

I assume nobody uses `gpu-descriptor` with `tracing` enabled atm?