### PR TITLE
Update erupt to 0.19.0+182

### DIFF
--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -14,5 +14,5 @@ readme = "../README.md"
 [dependencies]
 gpu-descriptor-types = { path = "../types", version = "0.1" }
 tracing = { version = "0.1", optional = true, default-features = false }
-erupt = "0.18.0"
+erupt = "0.19.0"
 smallvec = "1.0"

--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu-descriptor-erupt"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Zakarum <zakarumych@ya.ru>"]
 edition = "2018"
 description = "gpu-descriptor integration with erupt"

--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -132,7 +132,6 @@ impl DescriptorDevice<vk1_0::DescriptorSetLayout, vk1_0::DescriptorPool, vk1_0::
                     .flags(erupt_flags)
                     .build(),
                 None,
-                None,
             )
             .result();
 


### PR DESCRIPTION
[Changelog](https://gitlab.com/Friz64/erupt/-/blob/main/CHANGELOG.md#0190182-2021-06-21)