### PR TITLE
hashbrown to 0.12 and other minor fixes

### DIFF
--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -20,4 +20,4 @@ gpu-descriptor-types = { path = "../types", version = "0.1" }
 tracing = { version = "0.1", optional = true, default-features = false }
 bitflags = { version = "1.2", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-hashbrown = { version = "0.11" }
+hashbrown = { version = "0.12" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Core types of gpu-descriptor crate"
 keywords = ["gpu", "vulkan", "allocation", "no-std"]
 license = "MIT OR Apache-2.0"
-documentation = "https://docs.rs/gpu-descriptor-types/0.1.0"
+documentation = "https://docs.rs/gpu-descriptor-types"
 homepage = "https://github.com/zakarumych/gpu-descriptor"
 repository = "https://github.com/zakarumych/gpu-descriptor"
 

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -3,7 +3,7 @@ bitflags::bitflags! {
     ///
     /// Match corresponding bits in Vulkan.
     pub struct DescriptorPoolCreateFlags: u32 {
-        /// Allows freeing individial sets.
+        /// Allows freeing individual sets.
         const FREE_DESCRIPTOR_SET = 0x1;
 
         /// Allows allocating sets with layout created with matching backend-specific flag.


### PR DESCRIPTION
- updating the hashbrown dependency to 0.12
- a link to the documentation does not lead to the latest version
- minor typo