### PR TITLE
Bump `bitflags` v2

### DIFF
--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -18,6 +18,6 @@ default = ["std"]
 [dependencies]
 gpu-descriptor-types = { path = "../types", version = "0.1" }
 tracing = { version = "0.1", optional = true, default-features = false }
-bitflags = { version = "1.2", default-features = false }
+bitflags = { version = "2.0", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 hashbrown = { version = "0.12" }

--- a/gpu-descriptor/src/allocator.rs
+++ b/gpu-descriptor/src/allocator.rs
@@ -13,6 +13,7 @@ use {
 
 bitflags::bitflags! {
     /// Flags to augment descriptor set allocation.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct DescriptorSetLayoutCreateFlags: u32 {
         /// Specified that descriptor set must be allocated from\
         /// pool with `DescriptorPoolCreateFlags::UPDATE_AFTER_BIND`.

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/zakarumych/gpu-descriptor"
 repository = "https://github.com/zakarumych/gpu-descriptor"
 
 [dependencies]
-bitflags = { version = "1.2", default-features = false }
+bitflags = { version = "2.0", default-features = false }

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -2,6 +2,7 @@ bitflags::bitflags! {
     /// Flags to augment descriptor pool creation.
     ///
     /// Match corresponding bits in Vulkan.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct DescriptorPoolCreateFlags: u32 {
         /// Allows freeing individual sets.
         const FREE_DESCRIPTOR_SET = 0x1;


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

I was a bit liberal with deriving `std` traits on public types, which mimics the behavior of `bitflags` v1, let me know if we don't need all these traits. Potentially we could at least drop `PartialOrd` and `Ord`.

Replaces https://github.com/zakarumych/gpu-descriptor/pull/31.