### PR TITLE
Update hashbrown to 0.15

### DIFF
--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -22,4 +22,4 @@ bitflags = { version = "2.4", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [
     "derive",
 ] }
-hashbrown = { version = "0.14", default-features = false, features = ["ahash", "raw"] }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }


### PR DESCRIPTION
The `ahash` feature got renamed to `default-hasher`, and the `raw` feature didn't seem to be necessary (BTW that got renamed to `raw-entry`).
https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0150---2024-10-01