### PR TITLE
Update hashbrown to 0.16

### DIFF
--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -22,4 +22,4 @@ bitflags = { version = "2.6", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [
     "derive",
 ] }
-hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
+hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }


### PR DESCRIPTION
Similar to https://github.com/zakarumych/gpu-descriptor/pull/43.

`wgpu` 27 now has this dependency: https://github.com/gfx-rs/wgpu/pull/8194

This will help with not adding a third copy of it to our tree with https://github.com/ruffle-rs/ruffle/pull/21895.