### PR TITLE
Update hashbrown to 0.17

### DIFF
--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -22,4 +22,4 @@ bitflags = { version = "2.6", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [
     "derive",
 ] }
-hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }
+hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }

--- a/gpu-descriptor/Cargo.toml
+++ b/gpu-descriptor/Cargo.toml
@@ -22,4 +22,4 @@ bitflags = { version = "2.6", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [
     "derive",
 ] }
-hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
+hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }


### PR DESCRIPTION
Includes #45.

See: https://github.com/rust-lang/hashbrown/blob/main/CHANGELOG.md#0170---2026-04-06